### PR TITLE
uses program.prefix over hard coding

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ function recursivelyIterateProperties(types, jsonObject) {
             delete jsonObject[key]
         })
 
-        jsonObject["$ref"] = "file://build/schema/" + typeName + "#"
+        jsonObject["$ref"] = program.prefix + typeName + "#"
     }
 }
 


### PR DESCRIPTION
use the `program.prefix` for the ref over hardcoding the prefix
